### PR TITLE
forward named arguments in publish_site

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -238,7 +238,8 @@ quarto_publish_site <- function(input = getwd(),
     account = destination$account,
     server = destination$server,
     metadata = metadata,
-    contentCategory = "site"
+    contentCategory = "site",
+    ...
   )
 
 }


### PR DESCRIPTION
This PR aligns `publish_site()` with the functionality of `quarto_publish_doc()` and `quarto_publish_app()`, which already forward the ... to rsconnect.

Currently, `publish_site(..., appId = 123)` does not forward the appId to rsconnect.