### PR TITLE
Forward ... to rsconnect::deployApp in quarto_publish_site

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -238,9 +238,9 @@ quarto_publish_site <- function(input = getwd(),
     account = destination$account,
     server = destination$server,
     metadata = metadata,
-    contentCategory = "site"
+    contentCategory = "site",
+    ...
   )
-
 }
 
 


### PR DESCRIPTION
At the moment the ellipsis (...) are not forwarded from quarto_publish_site to rsconnect::deployApp.
Therefore, the following code would not forward the appID = 123 to rsconnect::deployApp and would not behave as expected (it fails silently)

```R
quarto::quarto_publish_site(
  server = "myserver.com", 
  account = "myuser",
  appId = 123 # this is not forwarded at the moment
)
```