### PR TITLE
Improve error message when quarto binary not found

### DIFF
--- a/R/quarto.R
+++ b/R/quarto.R
@@ -19,7 +19,7 @@ quarto_path <- function() {
 find_quarto <- function() {
   path <- quarto_path()
   if (is.null(path)) {
-    stop("Quarto command-line tools path not found! Please make sure you have installed and added Quarto to your PATH.")
+     stop("Quarto command-line tools path not found! Please make sure you have installed and added Quarto to your PATH or set the QUARTO_PATH environment variable.")
   } else {
     return(path)
   }

--- a/R/quarto.R
+++ b/R/quarto.R
@@ -19,9 +19,9 @@ quarto_path <- function() {
 find_quarto <- function() {
   path <- quarto_path()
   if (is.null(path)) {
-    stop("Unable to find quarto command line tools.")
+    stop("Quarto command-line tools path not found! Please make sure you have installed and added Quarto to your PATH.")
   } else {
-    path
+    return(path)
   }
 }
 


### PR DESCRIPTION
Incomplete error message - if the quarto_path() is null, it throws an error message using stop(), but the message itself is not explicit enough because it only says: "Unable to find quarto command line tools." It would be helpful to provide more detailed information on what is missing or how to install it.