### PR TITLE
introduced a output_dir parameter, which sets the --ouput-dir flag

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -10,6 +10,9 @@
 #'   `"all"` will render all formats defined within the file or project.
 #' @param output_file The name of the output file. If using `NULL` then the
 #'   output filename will be based on filename for the input file.
+#' @param output_dir The output directory, this is necessary to set in order
+#'   to fix a rendering issue with .html files, where formating and
+#'   images were missing. Additionally a subdirectory of the yaml output directory can be detailed.
 #' @param execute Whether to execute embedded code chunks.
 #' @param execute_params A list of named parameters that override custom params
 #'   specified within the YAML front-matter.
@@ -54,6 +57,7 @@
 quarto_render <- function(input = NULL,
                           output_format = NULL,
                           output_file = NULL,
+                          output_dir = NULL,
                           execute = TRUE,
                           execute_params = NULL,
                           execute_dir = NULL,
@@ -107,6 +111,9 @@ quarto_render <- function(input = NULL,
   }
   if (!missing(output_file)) {
     args <- c(args, "--output", output_file)
+  }
+  if (!missing(output_dir)) {
+    args <- c(args, "--output-dir", output_dir)
   }
   if (!missing(execute)) {
     args <- c(args, ifelse(isTRUE(execute), "--execute", "--no-execute"))


### PR DESCRIPTION
This helps to produce correctly rendered .html files, when e.g. rendering parametrized reports.

One example for a script to render a report for multiple inputs:
`library(tidyverse)
for (i in c(<vector-of-params$parameter-input>)) {
  print(i)
  quarto::quarto_render(
    input = "<your-quarto-document-template>.qmd",
    output_format = "html",
    output_file = 
      paste0(string = i, "<file-description>.html"),
    output_dir = "<output-dir-as-defined-in-quarto.yaml>",
    execute_params = list(
      parameter-input = i
    )
  )
  print(paste(i, "done"))
}`

This totally helped me to get this going nicely, hence a future implementation would be totally appreciated, and can of course be modified.
As the function `find_quarto()` is not available to a "normal" package user, an easily modified version of the `quarto_render()` function wasn't executable."

If not of interest, please just reject, as this is my first but very useful contribution to such a great package.
Thanks a lot,

jakob