### PR TITLE
Make `quarto_render(as_job = TRUE)` wrapable

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -269,7 +269,7 @@ find_app_primary_doc <- function(dir) {
           break
         }
       }
-      return (primary_doc)
+      return(primary_doc)
     }
   }
   return(NULL)

--- a/R/render.R
+++ b/R/render.R
@@ -86,8 +86,18 @@ quarto_render <- function(input = NULL,
   if (as_job && rstudioapi::isAvailable()) {
     message("Rendering project as background job (use as_job = FALSE to override)")
     script <- tempfile(fileext = ".R")
+    render_args <- rlang::call_args(sys.call())
+    render_args <- mapply(
+      function(arg, arg_name) paste0(
+        arg_name,
+        "="[nchar(arg_name) > 0L],
+        deparse1(eval(arg, envir = parent.frame(n = 3L)))
+      ),
+      render_args,
+      names(render_args)
+    )
     writeLines(
-      c("library(quarto)", deparse(sys.call())),
+      paste0("quarto::quarto_render(", paste0(render_args, collapse = ", "),")"),
       script
     )
     rstudioapi::jobRunScript(

--- a/R/render.R
+++ b/R/render.R
@@ -106,9 +106,8 @@ quarto_render <- function(input = NULL,
       workingDir = getwd(),
       importEnv = TRUE
     )
-    return (invisible(NULL))
+    return(invisible(NULL))
   }
-
 
   # build args
   args <- c("render", input)

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,4 +1,3 @@
-
 test_that("An error is reported when Quarto is not installed", {
   skip_if(!is.null(quarto_path()))
   expect_error(quarto_render("test.Rmd"))

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -11,3 +11,18 @@ test_that("R Markdown documents can be rendered", {
   expect_true(file.exists("test.html"))
   unlink("test-render.html")
 })
+
+
+test_that("`quarto_render()` is wrapable", {
+  skip_if(is.null(quarto_path()))
+  skip_if_not_installed("rstudioapi")
+  skip_if_not_installed("rprojroot")
+  skip_if(!rstudioapi::isAvailable())
+  dir <- rprojroot::find_testthat_root_file()
+  input <- file.path(dir, "test.Rmd")
+  output <- file.path(dir, "test.html")
+  wrapper <- function(path) quarto_render(path, quiet = TRUE)
+  wrapper(input)
+  expect_true(file.exists(output))
+  unlink(output)
+})


### PR DESCRIPTION
Currently, `quarto_render()` cannot be wrapped in another function *and* run as a background job (`as_job = TRUE`) at the same time because of a naive `deparse(Sys.call())` usage.

This PR properly evaluates and then deparses all provided arguments, so arguments are actually forwarded to `quarto_render()` when called inside another function.