### PR TITLE
ensure app_files is not a list for rsconnect::deployApp

### DIFF
--- a/R/publish.R
+++ b/R/publish.R
@@ -111,7 +111,7 @@ quarto_publish_doc <- function(input,
     }
 
     # include any explicit resources with app files
-    app_files <- unique(c(app_files, resources))
+    app_files <- unique(c(app_files, unlist(resources)))
 
     # deploy doc
     if (render == "server") {


### PR DESCRIPTION
When `resources` is an empty array in `quarto inspect`'s output, `resources` is an empty list, thus `app_files` becomes a list as well – but `rsconnect::deployApp` only accepts character vectors and NULL.