### PR TITLE
Add param `profile` to `quarto_inspect()` and `quarto_render()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: quarto
 Title: R Interface to 'Quarto' Markdown Publishing System
-Version: 1.3.2
+Version: 1.3.3
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # quarto (development version)
 
+* Add `profile` arguments to `quarto_render()` and `quarto_inspect()` (thanks, #95, @andrewheiss, #123, @salim-b).
+
 * Add `metadata` and `metadata_file` to `quarto_render()` to pass modify Quarto metadata from calling render. If both are set, `metadata` will be merged over `metadata_file` content. Internally, metadata will be passed as a `--metadata-file` to `quarto render` (thanks, @mcanouil, #52, @maelle, #49).
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/inspect.R
+++ b/R/inspect.R
@@ -38,7 +38,7 @@ quarto_inspect <- function(input = ".",
     args <- c(args, c("--profile", paste0(profile, collapse = ",")))
   }
 
-  res <- processx::run(quarto_bin, args)
+  res <- processx::run(quarto_bin, args, echo_cmd = getOption("quarto.echo_cmd", FALSE))
 
   fromJSON(res$stdout)
 }

--- a/R/inspect.R
+++ b/R/inspect.R
@@ -4,10 +4,8 @@
 #' config and engines. Inspecting an input path return its formats, engine,
 #' and dependent resources.
 #'
+#' @inheritParams quarto_render
 #' @param input The input file or project directory to inspect.
-#' @param profile [Quarto project
-#'   profile](https://quarto.org/docs/projects/profiles.html) to use. If
-#'   `NULL`, the default profile is used.
 #'
 #' @return Named list. For input files, the list contains the elements
 #'   `quarto`, `engines`, `formats`, `resources`, plus `project` if the file is

--- a/R/inspect.R
+++ b/R/inspect.R
@@ -37,7 +37,7 @@ quarto_inspect <- function(input = ".",
     command = quarto_bin,
     args = c(
       "inspect",
-      if (!is.null(profile)) c("--profile", profile),
+      if (!is.null(profile)) c("--profile", paste0(profile, collapse = ",")),
       path.expand(input)
     ),
     stdout = TRUE

--- a/R/inspect.R
+++ b/R/inspect.R
@@ -5,9 +5,14 @@
 #' and dependent resources.
 #'
 #' @param input The input file or project directory to inspect.
+#' @param profile [Quarto project
+#'   profile](https://quarto.org/docs/projects/profiles.html) to use. If
+#'   `NULL`, the default profile is used.
 #'
-#' @return Named list. For input files, the list has members engine, format,
-#'  and resources. For projects the list has members engines and config
+#' @return Named list. For input files, the list contains the elements
+#'   `quarto`, `engines`, `formats`, `resources`, plus `project` if the file is
+#'   part of a Quarto project. For projects, the list contains the elements
+#'   `quarto`, `dir`, `engines`, `config` and `files`.
 #'
 #' @importFrom jsonlite fromJSON
 #'
@@ -18,18 +23,27 @@
 #'
 #' # Inspect project
 #' quarto_inspect("myproject")
-#' }
 #'
+#' # Inspect project's advanced profile
+#' quarto_inspect(
+#'   input = "myproject",
+#'   profile = "advanced"
+#' )}
 #' @export
-quarto_inspect <- function(input = ".") {
+quarto_inspect <- function(input = ".",
+                           profile = NULL) {
 
   quarto_bin <- find_quarto()
 
-  output <- system2(quarto_bin, stdout = TRUE, c(
-    "inspect",
-    path.expand(input)
-  ))
+  output <- system2(
+    command = quarto_bin,
+    args = c(
+      "inspect",
+      if (!is.null(profile)) c("--profile", profile),
+      path.expand(input)
+    ),
+    stdout = TRUE
+  )
 
   fromJSON(output)
 }
-

--- a/R/inspect.R
+++ b/R/inspect.R
@@ -12,8 +12,6 @@
 #'   part of a Quarto project. For projects, the list contains the elements
 #'   `quarto`, `dir`, `engines`, `config` and `files`.
 #'
-#' @importFrom jsonlite fromJSON
-#'
 #' @examples
 #' \dontrun{
 #' # Inspect input file file
@@ -27,21 +25,20 @@
 #'   input = "myproject",
 #'   profile = "advanced"
 #' )}
+#' @importFrom jsonlite fromJSON
 #' @export
 quarto_inspect <- function(input = ".",
                            profile = NULL) {
 
   quarto_bin <- find_quarto()
 
-  output <- system2(
-    command = quarto_bin,
-    args = c(
-      "inspect",
-      if (!is.null(profile)) c("--profile", paste0(profile, collapse = ",")),
-      path.expand(input)
-    ),
-    stdout = TRUE
-  )
+  args <- c("inspect", path.expand(input))
 
-  fromJSON(output)
+  if (!is.null(profile)) {
+    args <- c(args, c("--profile", paste0(profile, collapse = ",")))
+  }
+
+  res <- processx::run(quarto_bin, args)
+
+  fromJSON(res$stdout)
 }

--- a/R/quarto-args.R
+++ b/R/quarto-args.R
@@ -1,0 +1,9 @@
+cli_arg_profile <- function(profile, ...) {
+  arg <- c("--profile", paste0(profile, collapse = ","))
+  append_cli_args(arg, ...)
+}
+
+append_cli_args <- function(new, append_to = NULL, after = length(append_to)) {
+  if (!is.null(append_to)) return(append(append_to, new, after))
+  new
+}

--- a/R/render.R
+++ b/R/render.R
@@ -66,7 +66,7 @@
 quarto_render <- function(input = NULL,
                           output_format = NULL,
                           output_file = NULL,
-                          execute = NULL,
+                          execute = TRUE,
                           execute_params = NULL,
                           execute_dir = NULL,
                           execute_daemon = NULL,
@@ -114,26 +114,27 @@ quarto_render <- function(input = NULL,
     return(invisible(NULL))
   }
 
+
   # build args
   args <- c("render", input)
-  if (!is.null(output_format)) {
+  if (!missing(output_format)) {
     args <- c(args, "--to", paste(output_format, collapse = ","))
   }
-  if (!is.null(output_file)) {
+  if (!missing(output_file)) {
     args <- c(args, "--output", output_file)
   }
-  if (!is.null(execute)) {
+  if (!missing(execute)) {
     args <- c(args, ifelse(isTRUE(execute), "--execute", "--no-execute"))
   }
-  if (!is.null(execute_params)) {
+  if (!missing(execute_params)) {
     params_file <- tempfile(pattern = "quarto-params", fileext = ".yml")
     write_yaml(execute_params, params_file)
     args <- c(args, "--execute-params", params_file)
   }
-  if (!is.null(execute_dir)) {
+  if (!missing(execute_dir)) {
     args <- c(args, "--execute-dir", execute_dir)
   }
-  if (!is.null(execute_daemon)) {
+  if (!missing(execute_daemon)) {
     args <- c(args, "--execute-daemon", as.character(execute_daemon))
   }
   if (isTRUE(execute_daemon_restart)) {
@@ -145,7 +146,7 @@ quarto_render <- function(input = NULL,
   if (isTRUE(use_freezer)) {
     args <- c(args, "--use-freezer")
   }
-  if (!is.null(cache)) {
+  if (!missing(cache)) {
     args <- c(args, ifelse(isTRUE(cache), "--cache", "--no-cache"))
   }
   if (isTRUE(cache_refresh)) {

--- a/R/render.R
+++ b/R/render.R
@@ -172,7 +172,7 @@ quarto_render <- function(input = NULL,
     args <- c(args, "--quiet")
   }
   if (!is.null(profile)) {
-    args <- c(args, "--profile", paste0(profile, collapse = ","))
+    args <- cli_arg_profile(profile, args)
   }
   if (!is.null(pandoc_args)) {
     args <- c(args, pandoc_args)

--- a/R/render.R
+++ b/R/render.R
@@ -54,7 +54,7 @@
 quarto_render <- function(input = NULL,
                           output_format = NULL,
                           output_file = NULL,
-                          execute = TRUE,
+                          execute = NULL,
                           execute_params = NULL,
                           execute_dir = NULL,
                           execute_daemon = NULL,
@@ -96,30 +96,29 @@ quarto_render <- function(input = NULL,
       workingDir = getwd(),
       importEnv = TRUE
     )
-    return (invisible(NULL))
+    return(invisible(NULL))
   }
-
 
   # build args
   args <- c("render", input)
-  if (!missing(output_format)) {
+  if (!is.null(output_format)) {
     args <- c(args, "--to", paste(output_format, collapse = ","))
   }
-  if (!missing(output_file)) {
+  if (!is.null(output_file)) {
     args <- c(args, "--output", output_file)
   }
-  if (!missing(execute)) {
+  if (!is.null(execute)) {
     args <- c(args, ifelse(isTRUE(execute), "--execute", "--no-execute"))
   }
-  if (!missing(execute_params)) {
+  if (!is.null(execute_params)) {
     params_file <- tempfile(pattern = "quarto-params", fileext = ".yml")
     write_yaml(execute_params, params_file)
     args <- c(args, "--execute-params", params_file)
   }
-  if (!missing(execute_dir)) {
+  if (!is.null(execute_dir)) {
     args <- c(args, "--execute-dir", execute_dir)
   }
-  if (!missing(execute_daemon)) {
+  if (!is.null(execute_daemon)) {
     args <- c(args, "--execute-daemon", as.character(execute_daemon))
   }
   if (isTRUE(execute_daemon_restart)) {
@@ -131,7 +130,7 @@ quarto_render <- function(input = NULL,
   if (isTRUE(use_freezer)) {
     args <- c(args, "--use-freezer")
   }
-  if (!missing(cache)) {
+  if (!is.null(cache)) {
     args <- c(args, ifelse(isTRUE(cache), "--cache", "--no-cache"))
   }
   if (isTRUE(cache_refresh)) {
@@ -153,9 +152,3 @@ quarto_render <- function(input = NULL,
   # no return value
   invisible(NULL)
 }
-
-
-
-
-
-

--- a/R/render.R
+++ b/R/render.R
@@ -30,8 +30,8 @@
 #' @param debug Leave intermediate files in place after render.
 #' @param quiet Suppress warning and other messages.
 #' @param profile [Quarto project
-#'   profile](https://quarto.org/docs/projects/profiles.html) to use. If
-#'   `NULL`, the default profile is used.
+#'   profile(s)](https://quarto.org/docs/projects/profiles.html) to use. Either
+#'   a character vector of profile names or `NULL` to use the default profile.
 #' @param pandoc_args Additional command line options to pass to pandoc.
 #' @param as_job Render as an RStudio background job. Default is "auto",
 #'   which will render individual documents normally and projects as
@@ -147,7 +147,7 @@ quarto_render <- function(input = NULL,
     args <- c(args, "--quiet")
   }
   if (!is.null(profile)) {
-    args <- c(args, "--profile", profile)
+    args <- c(args, "--profile", paste0(profile, collapse = ","))
   }
   if (!is.null(pandoc_args)) {
     args <- c(args, pandoc_args)

--- a/R/render.R
+++ b/R/render.R
@@ -29,6 +29,9 @@
 #' @param cache_refresh Force refresh of execution cache.
 #' @param debug Leave intermediate files in place after render.
 #' @param quiet Suppress warning and other messages.
+#' @param profile [Quarto project
+#'   profile](https://quarto.org/docs/projects/profiles.html) to use. If
+#'   `NULL`, the default profile is used.
 #' @param pandoc_args Additional command line options to pass to pandoc.
 #' @param as_job Render as an RStudio background job. Default is "auto",
 #'   which will render individual documents normally and projects as
@@ -65,6 +68,7 @@ quarto_render <- function(input = NULL,
                           cache_refresh = FALSE,
                           debug = FALSE,
                           quiet = FALSE,
+                          profile = NULL,
                           pandoc_args = NULL,
                           as_job = getOption("quarto.render_as_job", "auto")) {
 
@@ -141,6 +145,9 @@ quarto_render <- function(input = NULL,
   }
   if (isTRUE(quiet)) {
     args <- c(args, "--quiet")
+  }
+  if (!is.null(profile)) {
+    args <- c(args, "--profile", profile)
   }
   if (!is.null(pandoc_args)) {
     args <- c(args, pandoc_args)

--- a/man/quarto_inspect.Rd
+++ b/man/quarto_inspect.Rd
@@ -9,8 +9,8 @@ quarto_inspect(input = ".", profile = NULL)
 \arguments{
 \item{input}{The input file or project directory to inspect.}
 
-\item{profile}{\href{https://quarto.org/docs/projects/profiles.html}{Quarto project profile} to use. If
-\code{NULL}, the default profile is used.}
+\item{profile}{\href{https://quarto.org/docs/projects/profiles.html}{Quarto project profile(s)} to use. Either
+a character vector of profile names or \code{NULL} to use the default profile.}
 }
 \value{
 Named list. For input files, the list contains the elements

--- a/man/quarto_inspect.Rd
+++ b/man/quarto_inspect.Rd
@@ -4,14 +4,19 @@
 \alias{quarto_inspect}
 \title{Inspect Quarto Input File or Project}
 \usage{
-quarto_inspect(input = ".")
+quarto_inspect(input = ".", profile = NULL)
 }
 \arguments{
 \item{input}{The input file or project directory to inspect.}
+
+\item{profile}{\href{https://quarto.org/docs/projects/profiles.html}{Quarto project profile} to use. If
+\code{NULL}, the default profile is used.}
 }
 \value{
-Named list. For input files, the list has members engine, format,
-and resources. For projects the list has members engines and config
+Named list. For input files, the list contains the elements
+\code{quarto}, \code{engines}, \code{formats}, \code{resources}, plus \code{project} if the file is
+part of a Quarto project. For projects, the list contains the elements
+\code{quarto}, \code{dir}, \code{engines}, \code{config} and \code{files}.
 }
 \description{
 Inspect a Quarto project or input path. Inspecting a project returns its
@@ -25,6 +30,10 @@ quarto_inspect("notebook.Rmd")
 
 # Inspect project
 quarto_inspect("myproject")
-}
 
+# Inspect project's advanced profile
+quarto_inspect(
+  input = "myproject",
+  profile = "advanced"
+)}
 }

--- a/man/quarto_render.Rd
+++ b/man/quarto_render.Rd
@@ -19,6 +19,7 @@ quarto_render(
   cache_refresh = FALSE,
   debug = FALSE,
   quiet = FALSE,
+  profile = NULL,
   pandoc_args = NULL,
   as_job = getOption("quarto.render_as_job", "auto")
 )
@@ -62,6 +63,9 @@ respectively for Rmd and Jupyter input files).}
 \item{debug}{Leave intermediate files in place after render.}
 
 \item{quiet}{Suppress warning and other messages.}
+
+\item{profile}{\href{https://quarto.org/docs/projects/profiles.html}{Quarto project profile} to use. If
+\code{NULL}, the default profile is used.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc.}
 

--- a/man/quarto_render.Rd
+++ b/man/quarto_render.Rd
@@ -8,7 +8,7 @@ quarto_render(
   input = NULL,
   output_format = NULL,
   output_file = NULL,
-  execute = NULL,
+  execute = TRUE,
   execute_params = NULL,
   execute_dir = NULL,
   execute_daemon = NULL,

--- a/man/quarto_render.Rd
+++ b/man/quarto_render.Rd
@@ -64,8 +64,8 @@ respectively for Rmd and Jupyter input files).}
 
 \item{quiet}{Suppress warning and other messages.}
 
-\item{profile}{\href{https://quarto.org/docs/projects/profiles.html}{Quarto project profile} to use. If
-\code{NULL}, the default profile is used.}
+\item{profile}{\href{https://quarto.org/docs/projects/profiles.html}{Quarto project profile(s)} to use. Either
+a character vector of profile names or \code{NULL} to use the default profile.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc.}
 

--- a/man/quarto_render.Rd
+++ b/man/quarto_render.Rd
@@ -8,7 +8,7 @@ quarto_render(
   input = NULL,
   output_format = NULL,
   output_file = NULL,
-  execute = TRUE,
+  execute = NULL,
   execute_params = NULL,
   execute_dir = NULL,
   execute_daemon = NULL,

--- a/tests/testthat/project/_quarto-test.yml
+++ b/tests/testthat/project/_quarto-test.yml
@@ -1,0 +1,2 @@
+execute:
+  echo: true

--- a/tests/testthat/project/_quarto.yml
+++ b/tests/testthat/project/_quarto.yml
@@ -1,2 +1,5 @@
 project:
   type: site
+
+execute:
+  echo: false

--- a/tests/testthat/test-inspect.R
+++ b/tests/testthat/test-inspect.R
@@ -1,11 +1,22 @@
-test_that("R Markdown documents can be inspected", {
+test_that("Documents can be inspected", {
   skip_if_no_quarto()
-  metadata <- quarto_inspect("test.Rmd")
+  metadata <- quarto_inspect(test_path("test.Rmd"))
+  expect_type(metadata$formats, "list")
+  metadata <- quarto_inspect(test_path("test.qmd"))
+  expect_type(metadata$formats, "list")
+  metadata <- quarto_inspect(test_path("test.ipynb"))
   expect_type(metadata$formats, "list")
 })
 
 test_that("Quarto projects can be inspected", {
   skip_if_no_quarto()
-  metadata <- quarto_inspect("project")
+  metadata <- quarto_inspect(test_path("project"))
   expect_type(metadata$config, "list")
+})
+
+test_that("Quarto projects can be inspected with profile", {
+  skip_if_no_quarto()
+  metadata <- quarto_inspect(test_path("project"), "test")
+  expect_type(metadata$config, "list")
+  expect_identical(metadata$config$execute$echo, TRUE)
 })

--- a/tests/testthat/test-quarto-args.R
+++ b/tests/testthat/test-quarto-args.R
@@ -1,0 +1,13 @@
+test_that("append to existing", {
+  expect_identical(append_cli_args("a"), "a")
+  expect_identical(append_cli_args(c("a", "b")), c("a", "b"))
+  expect_identical(append_cli_args("c", c("a", "b")), c("a", "b", "c"))
+  expect_identical(append_cli_args("b", c("a", "c"), 1), c("a", "b", "c"))
+  expect_identical(append_cli_args(c("b","c"), c("a", "d"), 1), c("a", "b", "c", "d"))
+})
+
+test_that("create profile arg", {
+  expect_identical(cli_arg_profile("a"), c("--profile", "a"))
+  expect_identical(cli_arg_profile(c("a", "b")), c("--profile", "a,b"))
+  expect_identical(cli_arg_profile(c("a", "b"), "input.qmd"), c("input.qmd", "--profile", "a,b"))
+})

--- a/tests/testthat/test.ipynb
+++ b/tests/testthat/test.ipynb
@@ -1,0 +1,49 @@
+{
+  "cells": [
+    {
+      "cell_type": "raw",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "title: \"Untitled\"\n",
+        "format: html\n",
+        "---"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Quarto\n",
+        "\n",
+        "Quarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.\n",
+        "\n",
+        "## Running Code\n",
+        "\n",
+        "When you click the **Render** button a document will be generated that includes both content and the output of embedded code. You can embed code like this:\n",
+        "\n",
+        "```{r}\n",
+        "1 + 1\n",
+        "```\n",
+        "\n",
+        "You can add options to executable code like this\n",
+        "\n",
+        "```{r}\n",
+        "#| echo: false\n",
+        "2 * 2\n",
+        "```\n",
+        "\n",
+        "The `echo: false` option disables the printing of code (only output is displayed)."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "language": "python",
+      "display_name": "Python 3 (ipykernel)"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/tests/testthat/test.qmd
+++ b/tests/testthat/test.qmd
@@ -1,0 +1,25 @@
+---
+title: "Untitled"
+format: html
+---
+
+## Quarto
+
+Quarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.
+
+## Running Code
+
+When you click the **Render** button a document will be generated that includes both content and the output of embedded code. You can embed code like this:
+
+```{r}
+1 + 1
+```
+
+You can add options to executable code like this
+
+```{r}
+#| echo: false
+2 * 2
+```
+
+The `echo: false` option disables the printing of code (only output is displayed).


### PR DESCRIPTION
Also makes `quarto_render()` arg checks more robust (for the case where a `NULL` value is explicitly supplied).

Note that `profile` isn't checked for validity/existence, but forwarded 1:1 to `quarto inspect --profile`. This means that if a `profile` is specified that doesn't exist, Quarto silently falls back to the default profile.

Fixes https://github.com/quarto-dev/quarto-r/issues/95. 