### PR TITLE
Show gh icon on website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,8 +5,7 @@ template:
 
 navbar:
   structure:
-     left: [publishing, reference]
-     right: [news, search]
+     left: [publishing, reference, news]
   components:
      publishing:
       text: Publishing


### PR DESCRIPTION
To allow the github icon to show in the right corner, and overall make the layout more similar to other pkgdown sites. https://dplyr.tidyverse.org/