### PR TITLE
Add documentation for `quarto_args` of `quarto_render()`

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -44,7 +44,7 @@
 #' @param quarto_args Character vector of other `quarto` CLI arguments to append
 #'   to the Quarto command executed by this function. This is mainly intended for
 #'   advanced usage and useful for CLI arguments which are not yet mirrored in a
-#'   dedicated parameter of this \R function.
+#'   dedicated parameter of this \R function. See `quarto render --help` for options.
 #' @param pandoc_args Additional command line arguments to pass on to Pandoc.
 #' @param as_job Render as an RStudio background job. Default is "auto",
 #'   which will render individual documents normally and projects as
@@ -67,6 +67,7 @@
 #'
 #' # Override metadata
 #' quarto_render("notebook.Rmd", metadata = list(lang = "fr", execute = list(echo = FALSE)))
+#' quarto_render("notebook.Rmd", quarto_args = "--output-dir=new-directory")
 #' }
 #' @export
 quarto_render <- function(input = NULL,


### PR DESCRIPTION
I had the same issue as the one mentioned in https://github.com/quarto-dev/quarto-r/issues/81, but discovered late that I could do this.

I tried to find a place on the <https://quarto.org> website where they are all listed and documented, but I couldn't.

So I added a reference to the terminal, where we can find the options with

```terninal
quarto render --help
```

Needs `devtools::document()`

Adds an example that makes it more obvious that you can render to an output-dir with `quarto_render()`

