### PR TITLE
normalize quarto_path()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: quarto
 Title: R Interface to 'Quarto' Markdown Publishing System
-Version: 1.4.4.9001
+Version: 1.4.4.9002
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut",
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 - Add `quarto.quiet` options to allow more verbose error message when `quarto_*` function are used inside other package. 
   For example, inside **pkgdown** for building Quarto vignettes. **pkgdown** sets `quiet = TRUE` internally for its call to `quarto_render()`, 
   and setting `options(quarto.quiet = TRUE)` allows to overwrite this.
+  
+- `quarto_path()` now returns a normalized path with potential symlink resolved, for less confusion with `quarto_binary_sitrep()` (thanks, @jennybc).
 
 # quarto 1.4.4
 

--- a/R/quarto.R
+++ b/R/quarto.R
@@ -8,12 +8,13 @@
 #' @export
 quarto_path <- function() {
   path_env <- get_quarto_path_env()
-  if (is.na(path_env)) {
+  quarto_path <- if (is.na(path_env)) {
     path <- unname(Sys.which("quarto"))
     if (nzchar(path)) path else NULL
   } else {
     path_env
   }
+  normalizePath(quarto_path, winslash = "/", mustWork = FALSE)
 }
 
 get_quarto_path_env <- function() {


### PR DESCRIPTION
which resolves symlink

which creates no difference now with `quarto_binary_sitrep()` results

Previously it was confusing
```
> quarto::quarto_version()
[1] '1.5.47'
> quarto::quarto_path()
[1] "/usr/local/bin/quarto"
> quarto::quarto_binary_sitrep()
✔ quarto R package will use /Applications/quarto/bin/quarto
```