### PR TITLE
Correctly use same R version when calling quarto CLI from R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: quarto
 Title: R Interface to 'Quarto' Markdown Publishing System
-Version: 1.4.4.9010
+Version: 1.4.4.9011
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut",
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # quarto (development version)
 
+- Quarto CLI will now correctly use the same R version than the one used to run functions in this package (#204).
+
 - Add `quarto_available()` function to check if Quarto CLI is found (thanks, @hadley, #187).
 
 - `quarto_render()` now correctly set `as_job` when not inside RStudio IDE and required **rstudioapi** functions are not available (#203).

--- a/R/quarto.R
+++ b/R/quarto.R
@@ -128,6 +128,12 @@ quarto_run <- function(
   ...,
   .call = rlang::caller_env()
 ) {
+  # This is required due to a bug in QUARTO CLI, fixed only in 1.8+
+  # https://github.com/quarto-dev/quarto-cli/pull/12887
+  custom_env <- NULL
+  if (!quarto_available(min = "1.8.12")) {
+    custom_env <- c("current", QUARTO_R = R.home("bin"))
+  }
   res <- tryCatch(
     {
       processx::run(
@@ -136,6 +142,7 @@ quarto_run <- function(
         echo = echo,
         error_on_status = TRUE,
         echo_cmd = echo_cmd,
+        env = custom_env,
         ...
       )
     },

--- a/R/render.R
+++ b/R/render.R
@@ -43,7 +43,7 @@
 #'   `quarto.quiet` \R option or `QUARTO_R_QUIET` environment variable can be used to globally override a function call
 #'   (This can be useful to debug tool that calls `quarto_*` functions directly).
 #'
-#'   On Github Actions, it will always be `quiet=FALSE`.
+#'   On Github Actions, it will always be `quiet = FALSE`.
 #' @param profile [Quarto project
 #'   profile(s)](https://quarto.org/docs/projects/profiles.html) to use. Either
 #'   a character vector of profile names or `NULL` to use the default profile.
@@ -56,8 +56,6 @@
 #'   which will render individual documents normally and projects as
 #'   background jobs. Use the `quarto.render_as_job` \R option to control
 #'   the default globally.
-#'
-#' @importFrom rmarkdown relative_to
 #'
 #' @examples
 #' \dontrun{

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,6 @@
+#' @importFrom rmarkdown relative_to
 relative_to_wd <- function(path) {
-  relative_to(getwd(), path)
+  rmarkdown::relative_to(getwd(), path)
 }
 
 #' @importFrom yaml write_yaml

--- a/tests/testthat/_snaps/quarto.md
+++ b/tests/testthat/_snaps/quarto.md
@@ -4,7 +4,7 @@
       quarto_run(c("rend", "--quiet"))
     Condition
       Error:
-      x Error running quarto cli.
+      x Error returned by quarto CLI.
       i Rerun with `quiet = FALSE` to see the full error message.
       Caused by error:
       ! System command 'quarto' failed
@@ -15,8 +15,8 @@
       quarto_inspect()
     Condition
       Error in `quarto_inspect()`:
-      x Error running quarto cli.
-        -------------------------
+      x Error returned by quarto CLI.
+        -----------------------------
         ERROR: Book chapter 'intro.qmd' not found
         
         Stack trace:

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -6,7 +6,7 @@ test_that("An error is reported when Quarto is not installed", {
 
 test_that("R Markdown documents can be rendered", {
   skip_if_no_quarto()
-  quarto_render("test.Rmd", quiet = TRUE)
+  quarto_render(test_path("test.Rmd"), quiet = TRUE)
   expect_true(file.exists("test.html"))
   unlink("test.html")
 })


### PR DESCRIPTION
This is companion PR to a problem in Quarto CLI
- https://github.com/quarto-dev/quarto-cli/pull/12887

We need to do that so that the problem is fixed for other versions than future Quarto 1.8