### PR TITLE
`output_file` now map to `output-file` Quarto meta and not the cli flag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: quarto
 Title: R Interface to 'Quarto' Markdown Publishing System
-Version: 1.4.4.9017
+Version: 1.4.4.9018
 Authors@R: c(
     person("JJ", "Allaire", , "jj@posit.co", role = "aut",
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # quarto (development version)
 
+- `quarto_render(output_file = )` now sets the `output-file` Quarto metadata instead of the `--output` CLI flag. This allows the output file information to correctly be processed by Quarto, as if passed in a YAML header. e.g. it allows to support multiple output formats in the same render call. `quarto_render(quarto_args = c('--output', 'dummy.html'))` can still be used to set the `--output` CLI flag to enforce using the CLI flag and not the metadata processed by Quarto (#251, #43).
+
 - Added `check_newer_version()` function to check if a newer version of Quarto is available. The function compares the current Quarto version against the latest stable and prerelease versions. It is aimed for verbosity by default (`verbose = TRUE`), but `verbose = FALSE` can also be set for just checking update availability with TRUE or FALSE return values. Version information is cached per session for up to 24 hours to minimize network requests.
 
 - Added `write_yaml_metadata_block()` function to dynamically set YAML metadata in Quarto documents from R code chunks. This addresses the limitation where Quarto metadata must be static and defined in the document header. The function enables conditional content and metadata-driven document behavior based on R computations (thanks, @kmasiello, #137, #160).

--- a/R/render.R
+++ b/R/render.R
@@ -154,8 +154,11 @@ quarto_render <- function(
   if (!missing(output_format)) {
     args <- c(args, "--to", paste(output_format, collapse = ","))
   }
-  if (!missing(output_file)) {
-    args <- c(args, "--output", output_file)
+  if (!is.null(output_file)) {
+    # handle problem with cli flag
+    # https://github.com/quarto-dev/quarto-cli/issues/8399
+    # args <- c(args, "--output", output_file)
+    metadata[['output-file']] <- output_file
   }
   if (!missing(execute)) {
     args <- c(args, ifelse(isTRUE(execute), "--execute", "--no-execute"))
@@ -187,7 +190,7 @@ quarto_render <- function(
     args <- c(args, "--cache-refresh")
   }
   # metadata to pass to quarto render
-  if (!missing(metadata)) {
+  if (!is.null(metadata)) {
     # We merge meta if there is metadata_file passed
     if (!missing(metadata_file)) {
       metadata <- merge_list(

--- a/R/render.R
+++ b/R/render.R
@@ -193,10 +193,8 @@ quarto_render <- function(
   if (!is.null(metadata)) {
     # We merge meta if there is metadata_file passed
     if (!missing(metadata_file)) {
-      metadata <- merge_list(
-        yaml::read_yaml(metadata_file, eval.expr = FALSE),
-        metadata
-      )
+      file_content <- yaml::read_yaml(metadata_file, eval.expr = FALSE)
+      metadata <- merge_list(file_content, metadata)
     }
     meta_file <- tempfile(pattern = "quarto-meta", fileext = ".yml")
     on.exit(unlink(meta_file), add = TRUE)

--- a/tests/testthat/_snaps/render/metadata-merged.test.out
+++ b/tests/testthat/_snaps/render/metadata-merged.test.out
@@ -1,6 +1,10 @@
 Pandoc
   Meta
     { unMeta =
-        fromList [ ( "title" , MetaInlines [ Str "test2" ] ) ]
+        fromList
+          [ ( "any" , MetaInlines [ Str "one" ] )
+          , ( "other" , MetaInlines [ Str "thing" ] )
+          , ( "title" , MetaInlines [ Str "test2" ] )
+          ]
     }
   [ Para [ Str "content" ] ]

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -94,6 +94,7 @@ local_quarto_project <- function(
 .render <- function(
   input,
   output_file = NULL,
+  quarto_args = NULL,
   ...,
   .quiet = TRUE,
   .env = parent.frame()
@@ -102,20 +103,31 @@ local_quarto_project <- function(
   skip_if_not_installed("withr")
   # work inside input directory
   withr::local_dir(dirname(input))
+  output_file_forced <- NULL
   if (is.null(output_file)) {
-    output_file <- basename(withr::local_file(
+    output_file_forced <- basename(withr::local_file(
       xfun::with_ext(input, "test.out"),
       .local_envir = .env
     ))
+    # we enforce output file using CLI arg
+    quarto_args <- c(
+      quarto_args,
+      "--output",
+      output_file_forced
+    )
+  } else {
+    NULL
   }
   expect_no_error(quarto_render(
     basename(input),
     output_file = output_file,
     quiet = .quiet,
+    quarto_args = quarto_args,
     ...
   ))
-  expect_true(file.exists(output_file))
-  normalizePath(output_file)
+  out <- output_file %||% output_file_forced
+  expect_true(file.exists(out))
+  normalizePath(out)
 }
 
 .render_and_read <- function(input, ...) {

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -99,3 +99,26 @@ test_that("`quarto_render(as_job = TRUE)` is wrapable", {
   Sys.sleep(10)
   expect_true(file.exists(output))
 })
+
+test_that("quarto_render allows to pass output-file meta", {
+  skip_if_no_quarto()
+  qmd <- local_qmd_file(c(
+    "---",
+    "title: Example title",
+    "format:",
+    "    html:",
+    "       toc: true",
+    "    docx:",
+    "        toc: true",
+    "---",
+    ""
+  ))
+  out <- quarto_render(
+    qmd,
+    output_file = "final_report",
+    output_format = "all",
+    quiet = TRUE
+  )
+  expect_true(file.exists("final_report.html"))
+  expect_true(file.exists("final_report.docx"))
+})

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -42,13 +42,13 @@ test_that("metadata-file and metadata are merged in quarto_render", {
   skip_if_not_installed("withr")
   qmd <- local_qmd_file(c("content"))
   yaml <- withr::local_tempfile(fileext = ".yml")
-  write_yaml(list(title = "test"), yaml)
+  write_yaml(list(title = "test", other = "thing"), yaml)
   expect_snapshot_qmd_output(
     name = "metadata-merged",
     input = qmd,
     output_format = "native",
     metadata_file = yaml,
-    metadata = list(title = "test2")
+    metadata = list(title = "test2", any = "one")
   )
 })
 
@@ -113,12 +113,13 @@ test_that("quarto_render allows to pass output-file meta", {
     "---",
     ""
   ))
-  out <- quarto_render(
+  quarto_render(
     qmd,
     output_file = "final_report",
     output_format = "all",
     quiet = TRUE
   )
+  withr::local_dir(dirname(qmd))
   expect_true(file.exists("final_report.html"))
   expect_true(file.exists("final_report.docx"))
 })


### PR DESCRIPTION
This is to fix #43 and #251 

This is changing how it works, but one can restore the previous behavior by setting the command line flag

````
quarto_render("test.qmd", quarto_args = c("--output", "test.html"))
````

And using the metadata seems to be a better default