### PR TITLE
theme helpers: provide links to examples

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -3,8 +3,13 @@
 #' Create a theme using background and foreground colors (`theme_colors_*`) or
 #' using a **brand.yml** file (`theme_brand_*`).
 #'
-#' The use of the theme will depend on the package. See the vignettes for
-#' usage examples.
+#' The use of the theme will depend on the package. Please see
+#' [light/dark renderings examples](https://examples.quarto.pub/lightdark-renderings-examples/ggplot2.html)
+#' for examples using each supported package with dark mode, `theme_brand_*`,
+#' and `renderings: [light, dark]`,
+#' or [theme helper vignetes](https://quarto-dev.github.io/quarto-r/articles/theme-helpers.html)
+#' for examples using each package and `theme_colors_*` to specify the
+#' background and foreground colors directly.
 #'
 #' @param bg The background color
 #' @param fg The foreground color

--- a/man/theme_helpers.Rd
+++ b/man/theme_helpers.Rd
@@ -45,6 +45,11 @@ Create a theme using background and foreground colors (\verb{theme_colors_*}) or
 using a \strong{brand.yml} file (\verb{theme_brand_*}).
 }
 \details{
-The use of the theme will depend on the package. See the vignettes for
-usage examples.
+The use of the theme will depend on the package. Please see
+\href{https://examples.quarto.pub/lightdark-renderings-examples/ggplot2.html}{light/dark renderings examples}
+for examples using each supported package with dark mode, \verb{theme_brand_*},
+and \verb{renderings: [light, dark]},
+or \href{https://quarto-dev.github.io/quarto-r/articles/theme-helpers.html}{theme helper vignetes}
+for examples using each package and \verb{theme_colors_*} to specify the
+background and foreground colors directly.
 }

--- a/vignettes/articles/theme-helpers.qmd
+++ b/vignettes/articles/theme-helpers.qmd
@@ -11,13 +11,17 @@ vignette: >
 
 ## Overview
 
-The **quarto** package includes functions to help you theme plotting and table packages, for example to provide [light and dark renderings](https://quarto.org/docs/computations/execution-options.html#cell-renderings).
+The **quarto** package includes helper functions for theming plotting and table packages.
 
 The functions return theme objects or functions, which are applied differently depending on the package.
 
-This vignette demonstrates adding background and foreground colors to outputs from each package.
+These are simple helper functions to get you started. Copy them if you to customize them further.
 
-These are very simple helper functions to get you started. If you need to customize them further, these functions can be copied from quarto-r.
+This vignette demonstrates adding background and foreground colors to outputs from each package using the `theme_colors_*` functions.
+
+Please see
+[light/dark renderings examples](https://examples.quarto.pub/lightdark-renderings-examples/ggplot2.html)
+for examples using each supported package with dark mode, `theme_brand_*`, and [`renderings: [light, dark]`](https://quarto.org/docs/computations/execution-options.html#cell-renderings)
 
 ## flextable
 


### PR DESCRIPTION
Hi @cderv, I am having trouble building the artifacts, but I think this should cover the need for examples of each theme helper function.

What do you think?

Are there other places where we should link these resources?
