### PR TITLE
Fix Windows libPaths propagation via Rscript command line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # quarto (development version)
 
+- On Windows, `.libPaths()` are now propagated to the R process run by Quarto through the Rscript command line (via `QUARTO_KNITR_RSCRIPT_ARGS`) instead of relying on the `R_LIBS` environment variable, which is not inherited by that process (#217).
+
 - `.libPaths()` from the calling R session will now be passed by default to all call to quarto as a subprocess. This should solve issue with **pkgdown** or when building vignettes.
 
 - Curly braces in Quarto CLI error messages are now escaped to prevent them from being interpreted as `cli` formatting syntax (#293).

--- a/R/quarto.R
+++ b/R/quarto.R
@@ -147,10 +147,20 @@ quarto_run <- function(
   # (e.g. to install dev package in a temporary library)
   opt_in_libpath <- getOption("quarto.use_libpaths", TRUE)
   if (isTRUE(opt_in_libpath) && !is.null(libpaths)) {
-    custom_env <- c(
-      custom_env,
-      R_LIBS = paste(libpaths, collapse = .Platform$path.sep)
-    )
+    libs <- paste(libpaths, collapse = .Platform$path.sep)
+    custom_env <- c(custom_env, R_LIBS = libs)
+
+    # On Windows, R_LIBS is not inherited by the Rscript process spawned by
+    # quarto.exe. Pass the lib paths through the Rscript command line instead
+    # (requires Quarto >= 1.7; older versions ignore the env var, in which case
+    # behavior is unchanged).
+    # https://github.com/quarto-dev/quarto-r/issues/217
+    if (.Platform$OS.type == "windows") {
+      rscript_args <- knitr_rscript_args(libs)
+      if (!is.null(rscript_args)) {
+        custom_env <- c(custom_env, QUARTO_KNITR_RSCRIPT_ARGS = rscript_args)
+      }
+    }
   }
 
   # This is required because `"current"` only is not supported by processx
@@ -187,6 +197,31 @@ quarto_run <- function(
   )
 
   invisible(res)
+}
+
+# hex-encode a string as its UTF-8 bytes, producing a comma-free pure-ASCII
+# payload safe for QUARTO_KNITR_RSCRIPT_ARGS (decoded by inst/rmd-init.R)
+hex_encode <- function(x) {
+  paste(sprintf("%02x", as.integer(charToRaw(enc2utf8(x)))), collapse = "")
+}
+
+# value for the QUARTO_KNITR_RSCRIPT_ARGS environment variable: the init
+# script shipped in inst/ (which becomes the Rscript entry point and restores
+# .libPaths() from the hex-encoded trailing argument `libs`, then sources
+# Quarto's knitr engine script), preserving any user-set value. Returns NULL
+# if the mechanism cannot be used.
+knitr_rscript_args <- function(libs) {
+  init_script <- system.file("rmd-init.R", package = "quarto")
+  # a comma in the path would break Quarto's comma-separated parsing of
+  # QUARTO_KNITR_RSCRIPT_ARGS; fall back to R_LIBS only in that case
+  if (!nzchar(init_script) || grepl(",", init_script, fixed = TRUE)) {
+    return(NULL)
+  }
+  user_args <- Sys.getenv("QUARTO_KNITR_RSCRIPT_ARGS", "")
+  paste(
+    c(if (nzchar(user_args)) user_args, init_script, hex_encode(libs)),
+    collapse = ","
+  )
 }
 
 quarto_run_what <- function(

--- a/inst/rmd-init.R
+++ b/inst/rmd-init.R
@@ -1,0 +1,19 @@
+# Entry point injected into the Rscript command line on Windows via
+# QUARTO_KNITR_RSCRIPT_ARGS. Restores .libPaths() from the hex-encoded
+# trailing argument, then sources Quarto's knitr engine script (which Quarto
+# CLI appends to the command line immediately after the hex payload).
+# Needed because environment variables are not inherited by the Rscript
+# process spawned by quarto.exe on Windows.
+# https://github.com/quarto-dev/quarto-r/issues/217
+local({
+  args <- commandArgs(trailingOnly = TRUE)
+  hex <- args[[1L]]
+  bytes <- as.raw(strtoi(
+    substring(hex, seq(1L, nchar(hex), 2L), seq(2L, nchar(hex), 2L)),
+    16L
+  ))
+  libs <- rawToChar(bytes)
+  Encoding(libs) <- "UTF-8"
+  .libPaths(strsplit(libs, .Platform$path.sep, fixed = TRUE)[[1L]])
+  source(args[[2L]]) # default local = FALSE evaluates in .GlobalEnv
+})

--- a/tests/testthat/test-libpaths.R
+++ b/tests/testthat/test-libpaths.R
@@ -1,0 +1,63 @@
+test_that("hex_encode() round-trips through rmd-init.R decoding", {
+  # mirror of the decoding in inst/rmd-init.R
+  hex_decode <- function(hex) {
+    bytes <- as.raw(strtoi(
+      substring(hex, seq(1L, nchar(hex), 2L), seq(2L, nchar(hex), 2L)),
+      16L
+    ))
+    x <- rawToChar(bytes)
+    Encoding(x) <- "UTF-8"
+    x
+  }
+  libs <- paste(
+    c("/tmp/lib with spaces", "/tmp/lib-éü"),
+    collapse = .Platform$path.sep
+  )
+  encoded <- hex_encode(libs)
+  # payload is comma-free pure ASCII (safe for QUARTO_KNITR_RSCRIPT_ARGS)
+  expect_true(grepl("^[0-9a-f]*$", encoded))
+  expect_identical(hex_decode(encoded), enc2utf8(libs))
+})
+
+test_that("knitr_rscript_args() builds init script + hex payload", {
+  skip_on_cran()
+  withr::local_envvar(QUARTO_KNITR_RSCRIPT_ARGS = NA)
+  parts <- strsplit(
+    knitr_rscript_args("C:/R/library"),
+    ",",
+    fixed = TRUE
+  )[[1L]]
+  expect_length(parts, 2L)
+  expect_match(parts[1L], "rmd-init\\.R$")
+  expect_identical(parts[2L], hex_encode("C:/R/library"))
+})
+
+test_that("knitr_rscript_args() preserves user-set QUARTO_KNITR_RSCRIPT_ARGS", {
+  skip_on_cran()
+  withr::local_envvar(
+    QUARTO_KNITR_RSCRIPT_ARGS = "--vanilla,--no-init-file"
+  )
+  parts <- strsplit(
+    knitr_rscript_args("C:/R/library"),
+    ",",
+    fixed = TRUE
+  )[[1L]]
+  # user args stay first so they remain before the script position
+  expect_identical(parts[1:2], c("--vanilla", "--no-init-file"))
+  expect_length(parts, 4L)
+})
+
+test_that("rmd-init.R restores .libPaths() and sources the engine script", {
+  skip_on_cran()
+  init_script <- system.file("rmd-init.R", package = "quarto")
+  skip_if_not(nzchar(init_script))
+  tmp_lib <- withr::local_tempdir("tmp_libpath")
+  probe <- withr::local_tempfile(fileext = ".R")
+  writeLines('cat(.libPaths(), sep = "\n")', probe)
+  libs <- paste(c(tmp_lib, .libPaths()), collapse = .Platform$path.sep)
+  out <- processx::run(
+    file.path(R.home("bin"), "Rscript"),
+    args = c(init_script, hex_encode(libs), probe)
+  )$stdout
+  expect_match(out, basename(tmp_lib), fixed = TRUE)
+})

--- a/tests/testthat/test-quarto.R
+++ b/tests/testthat/test-quarto.R
@@ -161,9 +161,6 @@ test_that("quarto_available()", {
 test_that("quarto sees same libpaths as main process", {
   skip_if_no_quarto()
   skip_on_cran()
-  # Issue on windows with libpaths
-  # https://github.com/quarto-dev/quarto-r/issues/217
-  skip_on_os("windows")
   qmd <- local_qmd_file(c("```{r}", "#| echo: false", ".libPaths()", "```"))
   tmp_lib <- withr::local_tempdir("tmp_libpath")
   withr::local_libpaths(tmp_lib, action = "prefix")


### PR DESCRIPTION
## Problem

On Windows, `.libPaths()` from the calling R session never reach the R process that executes knitr chunks, so `quarto_render()` fails to find packages in non-default libraries (e.g. R CMD build's temp library during vignette rebuilding). Fixes #217.

## Root cause

The process chain is `R session → quarto.exe → Rscript rmd.R`. `quarto_run()` passes `R_LIBS` as an environment variable (via processx), which works on Unix, but on Windows the variable is not inherited across the second hop when quarto.exe (Deno) spawns Rscript. Environment variables are lost on that hop, but **command-line arguments are passed reliably**.

## Fix

Use [`QUARTO_KNITR_RSCRIPT_ARGS`](https://github.com/quarto-dev/quarto-cli/pull/11337) (Quarto ≥ 1.7), which quarto.exe reads from its own environment (first hop works) and inserts into the Rscript command line:

- New `inst/rmd-init.R` becomes the Rscript entry point. It restores `.libPaths()` from a hex-encoded trailing argument read via `commandArgs(trailingOnly = TRUE)`, then `source()`s Quarto's real `rmd.R` (appended to the command line by Quarto CLI), so rendering proceeds exactly as before.
- Hex encoding (of UTF-8 bytes) keeps the payload comma-free — Quarto splits the env var on `,` — and pure ASCII, immune to Windows quoting issues and non-ASCII path mangling.
- `R_LIBS` is still set on all platforms (unchanged Unix mechanism); both channels share the same opt-out (`options(quarto.use_libpaths = FALSE)` / `libpaths = NULL`).
- Quarto < 1.7 ignores the unknown env var, degrading gracefully to current behavior.

Note `Rscript -e '...' script.R` runs only the expression (the script never runs), which is why the init-script + trailing-args pattern is used rather than `-e` injection.

Supersedes the `R_ENVIRON_USER` approach in #298, which relies on the same broken env-var channel.

## Tests

- Removed `skip_on_os("windows")` from `"quarto sees same libpaths as main process"` — it should now pass on Windows CI.
- New `tests/testthat/test-libpaths.R`: hex round-trip (spaces, non-ASCII), `QUARTO_KNITR_RSCRIPT_ARGS` construction and user-value preservation, and an end-to-end `Rscript inst/rmd-init.R <hex> probe.R` run.
- Verified locally against the real Quarto CLI that rendering with the injected args restores the temp library in the rendered document's `.libPaths()` output.