### PR TITLE
Fix quarto_preview_stop process tracking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     jsonlite,
     later,
     lifecycle,
-    processx,
+    processx (>= 3.2.0),
     rlang,
     rmarkdown,
     rstudioapi,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # quarto (development version)
 
+- `quarto_preview_stop()` now reliably stops the running preview server by
+  preserving its process state across calls (thanks, @jabenninghoff, #304).
+
 - `.libPaths()` from the calling R session will now be passed by default to all call to quarto as a subprocess. This should solve issue with **pkgdown** or when building vignettes.
 
 - Curly braces in Quarto CLI error messages are now escaped to prevent them from being interpreted as `cli` formatting syntax (#293).

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -2,7 +2,7 @@
 # Using convention in https://github.com/tidyverse/design/issues/126
 the <- rlang::new_environment(
   list(
-    preview_infos = list()
+    preview_infos = rlang::new_environment(parent = emptyenv())
 
     # other possibles values in this env but should not exist because of env_cache usage
     # latest_stable = list(date = NULL, infos = NULL),

--- a/R/daemon.R
+++ b/R/daemon.R
@@ -100,7 +100,8 @@ run_serve_daemon <- function(
     args,
     wd = wd,
     stdout = "|",
-    stderr = "2>&1"
+    stderr = "2>&1",
+    cleanup_tree = TRUE
   )
 
   # wait for port to be bound to
@@ -181,14 +182,14 @@ stop_serve_daemon <- function(command) {
   quarto <- the$preview_infos
   ps_key <- paste0(command, "_ps")
   if (!is.null(quarto[[ps_key]])) {
-    if (quarto[[ps_key]]$is_alive()) {
-      ps <- quarto[[ps_key]]
-      quarto[[ps_key]] <- NULL
+    ps <- quarto[[ps_key]]
+    quarto[[ps_key]] <- NULL
+    if (ps$is_alive()) {
       ps$interrupt()
       ps$poll_io(500)
-      ps$kill()
-      ps$wait(3000)
     }
+    ps$kill_tree()
+    ps$wait(3000)
   }
   Sys.sleep(0.5)
   invisible()

--- a/tests/testthat/test-preview.R
+++ b/tests/testthat/test-preview.R
@@ -1,3 +1,81 @@
+test_that("quarto_preview_stop stops the preview server", {
+  skip_if_no_quarto()
+  skip_if_not_installed("callr")
+  skip_if_not_installed("pkgload")
+  skip_on_cran()
+
+  tmp_dir <- withr::local_tempdir()
+  input <- file.path(tmp_dir, "test.qmd")
+  xfun::write_utf8(c("---", "title: Test", "---", "", "# Hello"), input)
+
+  result_file <- file.path(tmp_dir, "result.rds")
+  stdout_file <- file.path(tmp_dir, "stdout.log")
+  stderr_file <- file.path(tmp_dir, "stderr.log")
+
+  preview_process <- callr::r_bg(
+    function(package_path, input, result_file) {
+      pkgload::load_all(package_path, quiet = TRUE)
+
+      port <- quarto:::find_port()
+      quarto::quarto_preview(
+        input,
+        port = port,
+        browse = FALSE,
+        quiet = TRUE
+      )
+      quarto::quarto_preview_stop()
+      saveRDS(quarto:::port_active(port), result_file)
+
+      # Keep the parent alive so the test can reliably terminate the full tree.
+      repeat {
+        Sys.sleep(1)
+      }
+    },
+    args = list(
+      package_path = testthat::test_path("..", ".."),
+      input = input,
+      result_file = result_file
+    ),
+    stdout = stdout_file,
+    stderr = stderr_file,
+    supervise = TRUE
+  )
+  withr::defer({
+    if (preview_process$is_alive()) {
+      preview_process$kill_tree()
+      preview_process$wait(5000)
+    }
+  })
+
+  deadline <- Sys.time() + 30
+  while (
+    !file.exists(result_file) &&
+      preview_process$is_alive() &&
+      Sys.time() < deadline
+  ) {
+    Sys.sleep(0.1)
+  }
+
+  if (!file.exists(result_file)) {
+    output <- c(
+      readLines(stdout_file, warn = FALSE),
+      readLines(stderr_file, warn = FALSE)
+    )
+    fail(paste(
+      c("Preview subprocess did not return a result.", output),
+      collapse = "\n"
+    ))
+    return()
+  }
+
+  port_is_active <- readRDS(result_file)
+  preview_process$kill_tree()
+  preview_process$wait(5000)
+
+  expect_identical(port_is_active, FALSE)
+})
+
+
 test_that("quarto_preview default functionality", {
   skip("quarto-preview test only works interactively")
   skip_if_no_quarto()

--- a/tests/testthat/test-preview.R
+++ b/tests/testthat/test-preview.R
@@ -3,6 +3,16 @@ test_that("quarto_preview_stop stops the preview server", {
   skip_if_not_installed("callr")
   skip_on_cran()
 
+  package_path <- testthat::test_path("..", "..")
+  source_r_dir <- file.path(package_path, "R")
+  is_source_tree <-
+    file.exists(file.path(package_path, "DESCRIPTION")) &&
+    dir.exists(source_r_dir) &&
+    length(list.files(source_r_dir, pattern = "\\.[Rr]$")) > 0
+  if (is_source_tree) {
+    skip_if_not_installed("pkgload")
+  }
+
   tmp_dir <- withr::local_tempdir()
   input <- file.path(tmp_dir, "test.qmd")
   xfun::write_utf8(c("---", "title: Test", "---", "", "# Hello"), input)
@@ -12,13 +22,7 @@ test_that("quarto_preview_stop stops the preview server", {
   stderr_file <- file.path(tmp_dir, "stderr.log")
 
   preview_process <- callr::r_bg(
-    function(package_path, input, result_file) {
-      source_r_dir <- file.path(package_path, "R")
-      is_source_tree <-
-        file.exists(file.path(package_path, "DESCRIPTION")) &&
-        dir.exists(source_r_dir) &&
-        length(list.files(source_r_dir, pattern = "\\.[Rr]$")) > 0
-
+    function(package_path, is_source_tree, input, result_file) {
       if (is_source_tree) {
         pkgload::load_all(package_path, quiet = TRUE)
       } else {
@@ -41,7 +45,8 @@ test_that("quarto_preview_stop stops the preview server", {
       }
     },
     args = list(
-      package_path = testthat::test_path("..", ".."),
+      package_path = package_path,
+      is_source_tree = is_source_tree,
       input = input,
       result_file = result_file
     ),

--- a/tests/testthat/test-preview.R
+++ b/tests/testthat/test-preview.R
@@ -1,7 +1,6 @@
 test_that("quarto_preview_stop stops the preview server", {
   skip_if_no_quarto()
   skip_if_not_installed("callr")
-  skip_if_not_installed("pkgload")
   skip_on_cran()
 
   tmp_dir <- withr::local_tempdir()
@@ -14,7 +13,17 @@ test_that("quarto_preview_stop stops the preview server", {
 
   preview_process <- callr::r_bg(
     function(package_path, input, result_file) {
-      pkgload::load_all(package_path, quiet = TRUE)
+      source_r_dir <- file.path(package_path, "R")
+      is_source_tree <-
+        file.exists(file.path(package_path, "DESCRIPTION")) &&
+        dir.exists(source_r_dir) &&
+        length(list.files(source_r_dir, pattern = "\\.[Rr]$")) > 0
+
+      if (is_source_tree) {
+        pkgload::load_all(package_path, quiet = TRUE)
+      } else {
+        loadNamespace("quarto")
+      }
 
       port <- quarto:::find_port()
       quarto::quarto_preview(


### PR DESCRIPTION
## Summary

- store preview daemon state in a shared environment so process updates persist across calls
- add a subprocess regression test verifying that stopping a preview releases its port
- support both source-tree development tests and installed-package checks

Closes #304

## Testing

- `devtools::test(filter = "preview")` — 1 passed, 2 pre-existing interactive skips
- `devtools::check(document = FALSE, manual = FALSE, args = "--no-vignettes", build_args = "--no-build-vignettes")` — 0 errors; vignette warnings expected because vignette building was disabled